### PR TITLE
feat(VNumberInput): decimal separator from locale

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -12,6 +12,7 @@ import { useHold } from './hold'
 import { useFocus } from '@/composables/focus'
 import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
+import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
@@ -94,7 +95,8 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const { isFocused, focus, blur } = useFocus(props)
 
-    const decimalSeparator = computed(() => props.decimalSeparator?.[0] || '.')
+    const { decimalSeparator: decimalSeparatorFromLocale } = useLocale()
+    const decimalSeparator = computed(() => props.decimalSeparator?.[0] || decimalSeparatorFromLocale.value)
 
     function correctPrecision (val: number, precision = props.precision, trim = true) {
       const fixed = precision == null

--- a/packages/vuetify/src/composables/locale.ts
+++ b/packages/vuetify/src/composables/locale.ts
@@ -10,6 +10,7 @@ export interface LocaleMessages {
 }
 
 export interface LocaleOptions {
+  decimalSeparator?: string
   messages?: LocaleMessages
   locale?: string
   fallback?: string
@@ -18,6 +19,7 @@ export interface LocaleOptions {
 
 export interface LocaleInstance {
   name: string
+  decimalSeparator: Ref<string>
   messages: Ref<LocaleMessages>
   current: Ref<string>
   fallback: Ref<string>

--- a/packages/vuetify/src/locale/adapters/vue-i18n.ts
+++ b/packages/vuetify/src/locale/adapters/vue-i18n.ts
@@ -61,7 +61,7 @@ function createProvideFunction (data: {
       current,
       fallback,
       messages,
-      decimalSeparator: toRef(() => inferDecimalSeparator(i18n.n)),
+      decimalSeparator: toRef(() => props.decimalSeparator ?? inferDecimalSeparator(i18n.n)),
       t: (key: string, ...params: unknown[]) => i18n.t(key, params),
       n: i18n.n,
       provide: createProvideFunction({ current, fallback, messages, useI18n: data.useI18n }),

--- a/packages/vuetify/src/locale/adapters/vue-i18n.ts
+++ b/packages/vuetify/src/locale/adapters/vue-i18n.ts
@@ -2,7 +2,7 @@
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { watch } from 'vue'
+import { toRef, watch } from 'vue'
 
 // Types
 import type { Ref } from 'vue'
@@ -26,6 +26,10 @@ function useProvided <T> (props: any, prop: string, provided: Ref<T>) {
   })
 
   return internal as Ref<T>
+}
+
+function inferDecimalSeparator (format: (v: number) => string) {
+  return format(0.1).includes(',') ? ',' : '.'
 }
 
 function createProvideFunction (data: {
@@ -57,6 +61,7 @@ function createProvideFunction (data: {
       current,
       fallback,
       messages,
+      decimalSeparator: toRef(() => inferDecimalSeparator(i18n.n)),
       t: (key: string, ...params: unknown[]) => i18n.t(key, params),
       n: i18n.n,
       provide: createProvideFunction({ current, fallback, messages, useI18n: data.useI18n }),
@@ -74,6 +79,7 @@ export function createVueI18nAdapter ({ i18n, useI18n }: VueI18nAdapterParams): 
     current,
     fallback,
     messages,
+    decimalSeparator: toRef(() => inferDecimalSeparator(i18n.global.n)),
     t: (key: string, ...params: unknown[]) => i18n.global.t(key, params),
     n: i18n.global.n,
     provide: createProvideFunction({ current, fallback, messages, useI18n }),

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -2,7 +2,7 @@
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { ref, shallowRef, watch } from 'vue'
+import { ref, shallowRef, toRef, watch } from 'vue'
 import { consoleError, consoleWarn, getObjectValueByPath } from '@/util'
 
 // Locales
@@ -55,6 +55,26 @@ const createTranslateFunction = (
   }
 }
 
+function getDecimalSeparator (locale = 'en-US') {
+  const code = locale?.slice(-2).toUpperCase()
+  switch (true) {
+    case `AE AF AG AI AL AM AS AU AZ BD BH BM BS BT BW BY BZ CA CH CN DM DO EG ET FJ FO
+    GB GE GT GU HK HN IE IL IN IQ IR IS JM JO JP KE KG KH KR KW KZ LA LB LI LK MH MK MM
+    MN MO MT MV MX MY NI NL NP NZ OM PA PE PH PK PR QA SA SD SG SV SY TH TM TT TW UM US
+    UZ VI WS XK YE ZW`.includes(code): {
+      return '.'
+    }
+    case `AD AN AR AT AX BA BE BG BN BR CL CM CO CR CY CZ DE DJ DK DZ EC EE ES FI FR GF
+    GP GR HR HU ID IT LT LU LV LY MC MD ME MQ MZ NO PL PT PY RE RO RS RU SE SI SK SM TJ
+    TR UA UY VA VE VN ZA`.includes(code): {
+      return ','
+    }
+    default: {
+      return '.'
+    }
+  }
+}
+
 function createNumberFunction (current: Ref<string>, fallback: Ref<string>) {
   return (value: number, options?: Intl.NumberFormatOptions) => {
     const numberFormat = new Intl.NumberFormat([current.value, fallback.value], options)
@@ -89,6 +109,7 @@ function createProvideFunction (state: { current: Ref<string>, fallback: Ref<str
       current,
       fallback,
       messages,
+      decimalSeparator: toRef(() => getDecimalSeparator(current.value)),
       t: createTranslateFunction(current, fallback, messages),
       n: createNumberFunction(current, fallback),
       provide: createProvideFunction({ current, fallback, messages }),
@@ -106,6 +127,7 @@ export function createVuetifyAdapter (options?: LocaleOptions): LocaleInstance {
     current,
     fallback,
     messages,
+    decimalSeparator: toRef(() => getDecimalSeparator(current.value)),
     t: createTranslateFunction(current, fallback, messages),
     n: createNumberFunction(current, fallback),
     provide: createProvideFunction({ current, fallback, messages }),

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -112,7 +112,7 @@ export function createVuetifyAdapter (options?: LocaleOptions): LocaleInstance {
     current,
     fallback,
     messages,
-    decimalSeparator: toRef(() => inferDecimalSeparator(current, fallback)),
+    decimalSeparator: toRef(() => options?.decimalSeparator ?? inferDecimalSeparator(current, fallback)),
     t: createTranslateFunction(current, fallback, messages),
     n: createNumberFunction(current, fallback),
     provide: createProvideFunction({ current, fallback, messages }),

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -55,32 +55,17 @@ const createTranslateFunction = (
   }
 }
 
-function getDecimalSeparator (locale = 'en-US') {
-  const code = locale?.slice(-2).toUpperCase()
-  switch (true) {
-    case `AE AF AG AI AL AM AS AU AZ BD BH BM BS BT BW BY BZ CA CH CN DM DO EG ET FJ FO
-    GB GE GT GU HK HN IE IL IN IQ IR IS JM JO JP KE KG KH KR KW KZ LA LB LI LK MH MK MM
-    MN MO MT MV MX MY NI NL NP NZ OM PA PE PH PK PR QA SA SD SG SV SY TH TM TT TW UM US
-    UZ VI WS XK YE ZW`.includes(code): {
-      return '.'
-    }
-    case `AD AN AR AT AX BA BE BG BN BR CL CM CO CR CY CZ DE DJ DK DZ EC EE ES FI FR GF
-    GP GR HR HU ID IT LT LU LV LY MC MD ME MQ MZ NO PL PT PY RE RO RS RU SE SI SK SM TJ
-    TR UA UY VA VE VN ZA`.includes(code): {
-      return ','
-    }
-    default: {
-      return '.'
-    }
-  }
-}
-
 function createNumberFunction (current: Ref<string>, fallback: Ref<string>) {
   return (value: number, options?: Intl.NumberFormatOptions) => {
     const numberFormat = new Intl.NumberFormat([current.value, fallback.value], options)
 
     return numberFormat.format(value)
   }
+}
+
+function inferDecimalSeparator (current: Ref<string>, fallback: Ref<string>) {
+  const format = createNumberFunction(current, fallback)
+  return format(0.1).includes(',') ? ',' : '.'
 }
 
 function useProvided <T> (props: any, prop: string, provided: Ref<T>) {
@@ -109,7 +94,7 @@ function createProvideFunction (state: { current: Ref<string>, fallback: Ref<str
       current,
       fallback,
       messages,
-      decimalSeparator: toRef(() => getDecimalSeparator(current.value)),
+      decimalSeparator: toRef(() => inferDecimalSeparator(current, fallback)),
       t: createTranslateFunction(current, fallback, messages),
       n: createNumberFunction(current, fallback),
       provide: createProvideFunction({ current, fallback, messages }),
@@ -127,7 +112,7 @@ export function createVuetifyAdapter (options?: LocaleOptions): LocaleInstance {
     current,
     fallback,
     messages,
-    decimalSeparator: toRef(() => getDecimalSeparator(current.value)),
+    decimalSeparator: toRef(() => inferDecimalSeparator(current, fallback)),
     t: createTranslateFunction(current, fallback, messages),
     n: createNumberFunction(current, fallback),
     provide: createProvideFunction({ current, fallback, messages }),


### PR DESCRIPTION
## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="400">
      <v-locale-provider locale="pl">
        <v-number-input
          v-model="num"
          :precision="2"
          :step=".5"
          label="separator (comma) from locale"
        />
      </v-locale-provider>
      <v-locale-provider locale="pl">
        <v-number-input
          v-model="num"
          :precision="2"
          :step=".5"
          decimal-separator="."
          label="separator from locale overriden (dot)"
        />
      </v-locale-provider>
      <v-locale-provider locale="us">
        <v-number-input
          v-model="num"
          :precision="2"
          :step=".5"
          decimal-separator=","
          label="separator from locale overriden (comma)"
        />
      </v-locale-provider>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'
  const num = ref(32.5)
</script>
```
